### PR TITLE
Fix Byte Array Protocol Name

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -161,7 +161,7 @@ hash output, and on the size and quality of the key.
 ;; => true
 ----
 
-The key parameter can be any type that implements the *ByteArray* protocol
+The key parameter can be any type that implements the *IByteArray* protocol
 defined in the `buddy.core.codecs` namespace. It comes with default implementations
 for `byte[]` and `java.lang.String` and `nil`.
 


### PR DESCRIPTION
Commit 03f3215 changed the name from `ByteArray` to `IByteArray`.
